### PR TITLE
Send Deployment Files to Another GitHub Repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,16 @@ cache:
 script:
   - npm run build 
   - npm run export 
-  - touch out/.nojekyll 
+  - touch out/.nojekyll
 deploy:
   provider: pages 
   skip_cleanup: true 
   github_token: $github_token 
-  local_dir: out 
+  local_dir: out
+  target_branch: ecea
   on:
     all_branches: true
+    repo: Purdue-ECESS/website
     condition: $TRAVIS_BRANCH =~ ^(main)$
 
 


### PR DESCRIPTION
* To allow an overlay of Projects without the need to continuously rebuild the project (or pull deployment files), all deployment files will be redirected to another repository. The second repository will easily rebuild and redeploy the website. 